### PR TITLE
Fixed TypeError crash for successful deletes

### DIFF
--- a/netbox_python/rest.py
+++ b/netbox_python/rest.py
@@ -73,10 +73,11 @@ class RestClient:
 
         # If status_code in 200-299 range, return success Result with data, otherwise raise exception
         is_success = 299 >= response.status_code >= 200  # 200 to 299 is OK
+        no_content_success = response.status_code == 204 # 204 is OK. Means no content
         if is_success:
             # check if list - fixme: should have cleaner way to do this
             pagination = None
-            if "count" in data_out and "results" in data_out:
+            if not no_content_success and "count" in data_out and "results" in data_out:
                 pagination = {
                     "count": data_out.get("count"),
                     "next": data_out.get("next"),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Current behaviour expects responses to exists, even when deleting and receiving a 204 (success - no content response). The [NetBox documentation](https://demo.netbox.dev/static/docs/rest-api/overview/) states:

> Note that DELETE requests do not return any data: If successful, the API will return a 204 (No Content) response.

## What is the new behavior?

New behaviour is to skip pagination and reading the result if the response code is 204.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The current implementation raises a TypeError, so unless someone working around the crash by catching it, this change does not break anything.
