### PR TITLE
Initialize missing `ipam.vlan_group` object

### DIFF
--- a/netbox_python/api/ipam.py
+++ b/netbox_python/api/ipam.py
@@ -25,6 +25,7 @@ class ipam:
         self.service_templates = self._service_templates(client)
         self.services = self._services(client)
         self.vlan_groups = self._vlan_groups(client)
+        self.vlan_group = vlan_group(client)
         self.vlans = self._vlans(client)
         self.vrfs = self._vrfs(client)
         super().__init__()


### PR DESCRIPTION
Fixes #22 in the simplest way by just adding the missing `ipam.vlan_group` object (from already imported `vlan_group` class).